### PR TITLE
Refactor UnmarshalJson function

### DIFF
--- a/data/json.go
+++ b/data/json.go
@@ -5,13 +5,9 @@ import (
 	"io"
 )
 
-// UnmarshalJson will convert r's JSON-encoded content into a value of type T
-func UnmarshalJson[T any](r io.Reader) (T, error) {
+// DecodeJson will convert r's JSON-encoded content into a value of type T
+func DecodeJson[T any](r io.Reader) (T, error) {
 	var t T
-	content, err := io.ReadAll(r)
-	if err != nil {
-		return t, err
-	}
-	err = json.Unmarshal(content, &t)
+	err := json.NewDecoder(r).Decode(&t)
 	return t, err
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,7 +17,7 @@ func init() {
 
 // AddWord adds a new word to the graph. The request may optionally include the word's synonyms - if so, they are also added to the graph.
 func AddWord(c *gin.Context) {
-	request, err := data.UnmarshalJson[data.WordInfo](c.Request.Body)
+	request, err := data.DecodeJson[data.WordInfo](c.Request.Body)
 	if err != nil {
 		c.Status(http.StatusBadRequest)
 		return
@@ -48,7 +48,7 @@ func AddSynonyms(c *gin.Context) {
 		return
 	}
 
-	synonyms, err := data.UnmarshalJson[data.SynonymsInfo](c.Request.Body)
+	synonyms, err := data.DecodeJson[data.SynonymsInfo](c.Request.Body)
 	if err != nil {
 		c.Status(http.StatusBadRequest)
 		return


### PR DESCRIPTION
* Use `json.Decode` instead of `Unmarshal` because it accepts an `io.Reader` instead of `[]byte`, meaning we don't have to drain the `io.Reader` first before decoding the JSON content